### PR TITLE
Fix config file name conflict

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -28,7 +28,7 @@ export class ConfigAPI {
    * @param configDir The directory where the configuration file is located
    */
   constructor(configDir: string) {
-    this.configFile = configDir
+    this.configFile = `${configDir}-config`
     this.config = this.readConfig()
   }
 


### PR DESCRIPTION
Problem: The `src/lib/config.ts` file currently store profile information in the same file name as `oclif`'s `configDir`

```ts
constructor(configDir: string) {
    this.configFile = configDir
    this.config = this.readConfig()
}
  
 writeConfig() {
    const data = JSON.stringify(this.config)
    // Config file name is same as `configDir`
    fs.writeFileSync(this.configFile, data, {encoding: 'utf8'})
}
```

This is problematic because of potential naming conflict. Specifically, when an error happens, `oclif` will try to create an `error.log` file at the path `${configDir}/error.log`. However, since our own profile information file already exists with the same name of `${configDir}`, there will be "File already exists" exception

![dominos-cli-before](https://github.com/aydrian/dominos-cli-workshop/assets/55563202/b8d4dd00-ff5e-4298-8929-4cb45d98eabb)

Solution: Adding a `-config` suffix to avoid name conflict --> Now in case of error, the CLI will exit gracefully.
```ts
constructor(configDir: string) {
    this.configFile = `${configDir}-config`
    this.config = this.readConfig()
}
```